### PR TITLE
Fix: an other way to make typescript happy with imagetools url import 

### DIFF
--- a/src/lib/types/site.d.ts
+++ b/src/lib/types/site.d.ts
@@ -48,5 +48,18 @@ export namespace Site {
   export type DateConfig = {
     toPublishedString: { locales: string; options: Intl.DateTimeFormatOptions };
     toUpdatedString: { locales: string; options: Intl.DateTimeFormatOptions };
-  };
+  }
+
+  declare module "*&imagetools" {
+    /**
+     * Workaround found here
+     * - issue https://github.com/JonasKruckenberg/imagetools/issues/160#issuecomment-1009292026
+     * actual types
+     * - code https://github.com/JonasKruckenberg/imagetools/blob/main/packages/core/src/output-formats.ts
+     * - docs https://github.com/JonasKruckenberg/imagetools/blob/main/docs/guide/getting-started.md#metadata
+     */
+    const out;
+    export default out;
+  }
+
 }

--- a/user/config/site.ts
+++ b/user/config/site.ts
@@ -3,21 +3,16 @@ import type { Giscus } from '$lib/types/giscus';
 import type { DD } from '$lib/types/dd';
 
 import Avatar from '$assets/avatar.png';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import Avatar_128 from '$assets/avatar.png?w=128&h=128&format=avif;wepb';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import Avatar_48_PNG from '$assets/avatar.png?w=48&h=48';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import Avatar_96_PNG from '$assets/avatar.png?w=96&h=96';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import Avatar_192_PNG from '$assets/avatar.png?w=192&h=192';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import Avatar_512_PNG from '$assets/avatar.png?w=512&h=512';
+
+import Avatar_128 from '$assets/avatar.png?w=128&h=128&format=avif;wepb&imagetools';
+
+import Avatar_48_PNG from '$assets/avatar.png?w=48&h=48&imagetools';
+
+import Avatar_96_PNG from '$assets/avatar.png?w=96&h=96&imagetools';
+
+import Avatar_192_PNG from '$assets/avatar.png?w=192&h=192&imagetools';
+
+import Avatar_512_PNG from '$assets/avatar.png?w=512&h=512&imagetools';
 
 import SiteCover from '$assets/qwer.webp';
 


### PR DESCRIPTION
I've give a deep search into the imagetools // @ts-ignore thing in the config/site.ts

I've found a workaround in this post: https://github.com/JonasKruckenberg/imagetools/issues/160#issuecomment-1009292026

I have barely a little experience with typescript, so please test it for yourself.

Hope it helps.