### PR TITLE
fix: property name wrong "PostsYearMonthDate"

### DIFF
--- a/QWER/lib/processFile.js
+++ b/QWER/lib/processFile.js
@@ -55,7 +55,7 @@ export const convertPathToSlug = (file) => {
   _slug = `${_destPath.join('/')}`;
 
   if (UserConfig.RoutingRules) {
-    if (UserConfig.RoutingRules.PostsYearMonthDay) {
+    if (UserConfig.RoutingRules.PostsYearMonthDate) {
       _slug = rule_PostsYearMonthDate(file, _slug);
     }
   }


### PR DESCRIPTION
Hi! @kwchang0831 
I tried below new function that you, and found the wrong property code.
After modifying the code, I have already confirmed that this feature is working properly.

[Before] `UserConfig.RoutingRules.PostsYearMonthDay`
[After] `UserConfig.RoutingRules.PostsYearMonthDate`

[discussion#29](https://github.com/kwchang0831/svelte-QWER/discussions/29#discussioncomment-3723315)