### PR TITLE
✨ Cloudflare Pages support

### DIFF
--- a/.changeset/angry-otters-add.md
+++ b/.changeset/angry-otters-add.md
@@ -1,0 +1,5 @@
+---
+'@kwchang0831/svelte-qwer': minor
+---
+
+✨ Feat: Cloudflare Pages support

--- a/README-zh.md
+++ b/README-zh.md
@@ -90,7 +90,7 @@ npx degit kwchang0831/svelte-QWER my-blog
 
 - 🌐 多國語系 i18n 透過 [typesafe-i18n](https://github.com/ivanhofer/typesafe-i18n)。
 
-- 🚀 免費架設部落格於 [Vercel](https://vercel.com/) 或 [Netlify](https://Netlify.com/) 上。
+- 🚀 免費架設部落格於 [Vercel](https://vercel.com/), 或 [Netlify](https://Netlify.com/), 或 [Cloudflare Pages](https://pages.cloudflare.com/) 上。
 
 ## 📚 了解更多
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ npx degit kwchang0831/svelte-QWER my-blog
 
 - 🌐 i18n via [typesafe-i18n](https://github.com/ivanhofer/typesafe-i18n).
 
-- 🚀 Deploy the blog **Free** on [Vercel](https://vercel.com/) or [Netlify](https://Netlify.com/).
+- 🚀 Deploy the blog **Free** on [Vercel](https://vercel.com/), [Netlify](https://Netlify.com/), or [Cloudflare Pages](https://pages.cloudflare.com/).
 
 ## 📚 Learn More
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@iconify-json/vscode-icons": "^1.1.26",
     "@kwchang0831/qwer": "link:QWER",
     "@kwchang0831/svelte-qwer": "link:",
+    "@sveltejs/adapter-cloudflare": "^2.3.2",
     "@sveltejs/adapter-netlify": "2.0.8",
     "@sveltejs/adapter-node": "1.3.1",
     "@sveltejs/adapter-static": "2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@kwchang0831/svelte-qwer':
         specifier: 'link:'
         version: 'link:'
+      '@sveltejs/adapter-cloudflare':
+        specifier: ^2.3.2
+        version: 2.3.2(@sveltejs/kit@1.22.4)
       '@sveltejs/adapter-netlify':
         specifier: 2.0.8
         version: 2.0.8(@sveltejs/kit@1.22.4)
@@ -481,6 +484,10 @@ packages:
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
+    dev: true
+
+  /@cloudflare/workers-types@4.20230814.0:
+    resolution: {integrity: sha512-+jHiGjZg2UpULZSSHmHLqUG45TLg1s+uppSMlGvMn0u/xyFsRX9HX6b8Ydg/oHSp3jfSuPtX05GSvtgRAmrWTg==}
     dev: true
 
   /@esbuild/android-arm64@0.18.17:
@@ -1053,6 +1060,17 @@ packages:
   /@sindresorhus/is@5.6.0:
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
+    dev: true
+
+  /@sveltejs/adapter-cloudflare@2.3.2(@sveltejs/kit@1.22.4):
+    resolution: {integrity: sha512-BpgFmVJInF2D0Uo41gJtvYyTiZ6P/xkfrQSqPHQOGYsjvFeW+1AjX/8MPIJ3VJyvbVgyRaVKMBsXWHADbAYatQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^1.0.0
+    dependencies:
+      '@cloudflare/workers-types': 4.20230814.0
+      '@sveltejs/kit': 1.22.4(svelte@4.1.2)(vite@4.4.7)
+      esbuild: 0.18.17
+      worktop: 0.8.0-next.15
     dev: true
 
   /@sveltejs/adapter-netlify@2.0.8(@sveltejs/kit@1.22.4):
@@ -5546,6 +5564,11 @@ packages:
       functions-have-names: 1.2.3
     dev: true
 
+  /regexparam@2.0.1:
+    resolution: {integrity: sha512-zRgSaYemnNYxUv+/5SeoHI0eJIgTL/A2pUtXUPLHQxUldagouJ9p+K6IbIZ/JiQuCEv2E2B1O11SjVQy3aMCkw==}
+    engines: {node: '>=8'}
+    dev: true
+
   /registry-auth-token@5.0.2:
     resolution: {integrity: sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==}
     engines: {node: '>=14'}
@@ -6908,6 +6931,14 @@ packages:
   /word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /worktop@0.8.0-next.15:
+    resolution: {integrity: sha512-0ycNO52P6nVwsjr1y20zuf0nqJatAb8L7MODBfQIxbxndHV5O4s50oZZMHWhJG1RLpHwbK0Epq8aaQK4E2GlgQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mrmime: 1.0.1
+      regexparam: 2.0.1
     dev: true
 
   /wrap-ansi@6.2.0:

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -2,25 +2,34 @@ import adapterNode from '@sveltejs/adapter-node';
 import adapterStatic from '@sveltejs/adapter-static';
 import adapterVercel from '@sveltejs/adapter-vercel';
 import adapterNetlify from '@sveltejs/adapter-netlify';
+import adapterCloudflare from '@sveltejs/adapter-cloudflare';
 import preprocess from 'svelte-preprocess';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   preprocess: preprocess({ preserve: ['partytown'] }),
   kit: {
-    adapter: Object.keys(process.env).some((key) => key.includes('VERCEL'))
-      ? adapterVercel()
-      : Object.keys(process.env).some((key) => key.includes('NETLIFY'))
-      ? adapterNetlify()
-      : process.env.ADAPTER === 'node'
+    adapter: getAdapter(),
+    csp: { mode: 'auto' },
+  },
+};
+
+function getAdapter() {
+  if (Object.keys(process.env).some((key) => key.includes('VERCEL'))) {
+    return adapterVercel();
+  } else if (Object.keys(process.env).some((key) => key.includes('NETLIFY'))) {
+    return adapterNetlify();
+  } else if (Object.keys(process.env).some((key) => key.includes('CF_PAGES'))) {
+    return adapterCloudflare();
+  } else {
+    return process.env.ADAPTER === 'node'
       ? adapterNode({ out: 'build' })
       : adapterStatic({
           pages: 'build',
           assets: 'build',
           fallback: null,
-        }),
-    csp: { mode: 'auto' },
-  },
-};
+        });
+  }
+}
 
 export default config;


### PR DESCRIPTION
This should allow you to support Cloudflare Pages as a deployment target, with the below options (the default for SvelteKit on Cloudflare)

![image](https://github.com/kwchang0831/svelte-QWER/assets/523886/2b032694-a644-4071-8ca7-4e4252bfeaf2)

This does not include documentation updates for new deployed example sites, or new example sites on Cloudflare, as those would have to be created and maintained by this project's maintainers. I also only updated the English language README.

The lockfile's changes are the result of adding the cloudflare adapter via `pnpm i -D -w @sveltejs/adapter-cloudflare --ignore-scripts`