### PR TITLE
:bug: Fix: fix processImagePath to detect remote path

### DIFF
--- a/.changeset/serious-radios-jog.md
+++ b/.changeset/serious-radios-jog.md
@@ -1,0 +1,5 @@
+---
+'@kwchang0831/qwer': minor
+---
+
+fix processImagePath to detect remote path

--- a/QWER/lib/processFile.js
+++ b/QWER/lib/processFile.js
@@ -27,8 +27,14 @@ export const processRmDir = (dir) => {
   }
 };
 
+const isRemotePath = (path) => {
+  return path.startsWith('http://') || path.startsWith('https://');
+};
+
 export const processImagePath = (path, slug) => {
   if (!path || !slug) return;
+
+  if (isRemotePath(path)) return path;
 
   if (!isAbsolute(path)) {
     path = join(slug, path);


### PR DESCRIPTION

Fix `processImagePath` to detect remote paths.

The `processImagePath`  function cannot recognize paths that start with `http:// `or `https://`, so it cannot directly read images from image servers.

This change adds `isRemotePath` function to determine whether a path is a remote path. If it is a remote path, the original path is returned directly, and it will not be converted to an absolute path.

--- 

修復 `processImagePath` 無法識別遠端路徑的問題。

現有的 `processImagePath` 無法識別以 `http:// `或 `https:// `開頭的路徑，因此無法直接讀取圖床的圖片 URL。

本次修改新增了 `isRemotePath`來判斷路徑是否為遠端路徑。如果是遠端路徑，則直接回傳原始路徑，而不會將其轉換為絕對路徑。

