### PR TITLE
Added a script for streamlined creation of a blog folder and its corresponding index.md file.

### DIFF
--- a/.changeset/breezy-kangaroos-sleep.md
+++ b/.changeset/breezy-kangaroos-sleep.md
@@ -1,0 +1,5 @@
+---
+'@kwchang0831/svelte-qwer': minor
+---
+
+✨ feat: Added a script for streamlined creation of a blog folder and its corresponding index.md file.

--- a/.typesafe-i18n.json
+++ b/.typesafe-i18n.json
@@ -1,5 +1,5 @@
 {
-   "adapter": "svelte",
-   "esmImports": true,
-   "$schema": "https://unpkg.com/typesafe-i18n@5.26.2/schema/typesafe-i18n.json"
+  "adapter": "svelte",
+  "esmImports": true,
+  "$schema": "https://unpkg.com/typesafe-i18n@5.26.2/schema/typesafe-i18n.json"
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -58,6 +58,12 @@ npx degit kwchang0831/svelte-QWER my-blog
    pnpm dev
    ```
 
+1. 創建文章資料夾（如果您是 Windows 用戶，請確保使用一個支援 Bash 腳本的終端機，例如 Git Bash）。
+
+   ```bash
+   pnpm run createblog YOURDIRNAME
+   ```
+
 ## ✨ 功能
 
 - ⚡ 超快的網站速度。接近完美的 [PageSpeed](https://pagespeed.web.dev/) 跑分。

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ npx degit kwchang0831/svelte-QWER my-blog
    pnpm dev
    ```
 
+1. Create an article folder (For Windows users, make sure to use a terminal that supports Bash scripts, such as Git Bash).
+
+   ```bash
+   pnpm run createblog YOURDIRNAME
+
+   ```
+
 ## ✨ Features
 
 - ⚡ Super fast site performance. Near **Perfect** [PageSpeed](https://pagespeed.web.dev/) score.

--- a/create-blog.sh
+++ b/create-blog.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+BASE_PATH="./user/blogs"
+
+# Check if a directory name is provided
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <directory-name>"
+    exit 1
+fi
+
+# Every time you enter pnpm run createblog YourDirName, 
+# a folder will be created for you based on the following configuration, 
+# along with a default content for index.md. 
+# You are free to edit the information as needed.
+
+DIRECTORY="$BASE_PATH/$1"
+MD_TEMPLATE="---
+title: 
+description: 
+summary: 
+cover: ./cover.jpg
+coverCaption: Photo by
+coverStyle: 'IN'
+series_tag:
+series_title:
+tag:
+  - [JavaSript]
+---"
+
+# Ensure base path exists
+if [ ! -d "$BASE_PATH" ]; then
+    mkdir -p "$BASE_PATH"
+fi
+
+# Check if directory exists
+if [ -d "$DIRECTORY" ]; then
+    echo "Directory $DIRECTORY already exists!"
+else
+    mkdir "$DIRECTORY"
+    echo "$MD_TEMPLATE" > "$DIRECTORY/index.md"
+    echo "Directory $DIRECTORY and index.md created successfully!"
+fi

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "husky": "husky install && npx husky set .husky/pre-commit \"npx lint-staged\" && gitmoji -i",
     "typesafe-i18n": "typesafe-i18n",
     "changeset:add": "pnpm changeset add",
-    "deploy:vercel-local-build": "vercel build --prod && vercel deploy --prebuilt --prod"
+    "deploy:vercel-local-build": "vercel build --prod && vercel deploy --prebuilt --prod",
+    "createblog": "bash create-blog.sh"
   },
   "lint-staged": {
     "*.{html,scss,css,svelte,ts,js}": "prettier --write ."


### PR DESCRIPTION
Execute the command `pnpm run createblog YOURDIRNAME` from the root directory in your terminal to quickly create a folder under /user/blogs, along with an accompanying index.md file.