### PR TITLE
:bug: Fix: fix post_SEO for remote path

### DIFF
--- a/.changeset/shy-ants-hug.md
+++ b/.changeset/shy-ants-hug.md
@@ -1,0 +1,5 @@
+---
+'@kwchang0831/svelte-qwer': major
+---
+
+Fix post_SEO for remote image url

--- a/src/lib/components/post_SEO.svelte
+++ b/src/lib/components/post_SEO.svelte
@@ -9,7 +9,7 @@
   import { siteConfig } from '$config/site';
 
   export let post: Post.Post;
-  let post_cover: Asset.Image | undefined = $assets.get(post.cover ?? '');
+  let post_cover: Asset.Image | undefined | string = $assets.get(post.cover ?? '') || post.cover;
 </script>
 
 <svelte:head>
@@ -37,11 +37,14 @@
 
   <meta name="twitter:card" content="summary_large_image" />
 
-  {#if post_cover && post_cover.original}
+  {#if post_cover && typeof post_cover !== 'string' && post_cover.original}
     <meta property="og:image" content={new URL(post_cover.original, siteConfig.url).href} />
     <meta property="og:image:width" content={'' + post_cover.width} />
     <meta property="og:image:height" content={'' + post_cover.height} />
     <meta name="twitter:image" content={new URL(post_cover.original, siteConfig.url).href} />
+  {:else if typeof post_cover === 'string'}
+    <meta property="og:image" content={post_cover} />
+    <meta name="twitter:image" content={post_cover} />
   {:else}
     <meta property="og:image" content={new URL(siteConfig.cover, siteConfig.url).href} />
     <meta name="twitter:image" content={new URL(siteConfig.cover, siteConfig.url).href} />


### PR DESCRIPTION
This PR fixes an issue where `post_SEO` did not generate the correct Open Graph image when the cover was using a remote URL. This problem started after my previous PR #78, which allowed covers to use remote URLs.

But I am not sure if this is the best implementation. Initially, I thought about incorporating the remote URL during the `asset` generation process. However, I felt this might not align well with the intended use of `assets`. So, I ended up implementing this solution in `post_SEO`.

Any feedback is welcome.

