### PR TITLE
Added generated routes to the `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ __unconfig_vite.config.js
 /src/i18n/i18n-*
 # Local Netlify folder
 .netlify
+
+/src/routes/*/+page.svelte


### PR DESCRIPTION
By adding the generated routes to the .gitignore file, we ensure that these files are not tracked by Git.
This helps to avoid unnecessary versioning of autogenerated content, keeping the repository clean and preventing conflicts.