### PR TITLE
🩹 Mobile - center profile

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -65,7 +65,7 @@
     itemtype="https://schema.org/Blog"
     itemprop="blog"
     class="flex flex-nowrap justify-center flex-col items-center xl:hidden">
-    <div class="max-w-screen-md flex-1 relative ml6">
+    <div class="max-w-screen-md flex-1 relative">
       <IndexProfile class="flex flex-col gap2 items-center text-center" />
     </div>
     <div class="h-feed min-h-50vh flex-none w-full">


### PR DESCRIPTION
Removed spacing to center the profile section on mobile view.

Before:
![Before](https://github.com/user-attachments/assets/3139be86-0062-4131-ad9d-5369fd060e5c)

After:
![After](https://github.com/user-attachments/assets/63f94bf0-b317-4264-bfe2-9f65a9656840)
