### PR TITLE
✨ Add optional property to toggle post cover photo visibility

### DIFF
--- a/QWER/lib/processFile.js
+++ b/QWER/lib/processFile.js
@@ -134,6 +134,7 @@ const _processMD = (file, generateMeta) => {
     published: _meta['published'] ?? statSync(file).birthtime,
     updated: _meta['updated'] ?? statSync(file).mtime,
     cover: processImagePath(_meta['cover'], _slug),
+    coverInPost: _meta['coverInPost'],
     coverCaption: _meta['coverCaption'],
     coverStyle: _meta['coverStyle'] ?? UserConfig.DefaultCoverStyle,
     options: _meta['options'],

--- a/src/lib/components/post_heading.svelte
+++ b/src/lib/components/post_heading.svelte
@@ -8,6 +8,8 @@
   import LL from '$i18n/i18n-svelte';
 
   export let data: Post.Post;
+  // Show the coverInPost by default
+  const showCoverInPost = data.coverInPost ?? true;
 </script>
 
 <div class="flex flex-col pt8 mx8">
@@ -67,7 +69,7 @@
   <h1 itemprop="name headline" class="p-name text-4xl my4 mx--4 md:mx0">{data.title}</h1>
 
   <div class="mx--8 md:mx0">
-    {#if data.cover}
+    {#if data.cover && showCoverInPost}
       <ImgZoom
         src={data.cover}
         class="w-full h-auto aspect-auto object-cover md:(rounded-2xl shadow-xl)"

--- a/src/lib/types/post.d.ts
+++ b/src/lib/types/post.d.ts
@@ -12,6 +12,7 @@ export namespace Post {
     updated: string;
     created: string;
     cover?: string;
+    coverInPost?: boolean;
     coverCaption?: string;
     coverStyle: CoverStyle;
     options?: Array<string>;


### PR DESCRIPTION
By default, the cover photo added to a post on the main indexing page is also displayed within the post itself. This update introduces a new optional property, `coverInPost`, allowing users to customize this behavior.
If `coverInPost: false` is added to the `index.md` file, the cover photo will no longer appear inside the post, while still being displayed on the main page. This maintains the current default behavior while offering better flexibility.